### PR TITLE
Start watch task implementation

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,7 +9,8 @@ module.exports = function (grunt) {
       },
       runner: ['runner/**/*.js'],
       task: ['task/**/*.js'],
-      tests: ['test/**/*.js']
+      tests: ['test/**/*.js'],
+      changed: '<%= watch.files.changed %>'
     },
     multi: {
       tara: {},
@@ -27,6 +28,29 @@ module.exports = function (grunt) {
         dest: 'tmp/concat.js'
       }
     },
+    watch: {
+      files: {
+        files: ['test/fixtures/**/*.js'],
+        tasks: ['series1', 'jshint:changed']
+      },
+      tasks: {
+        options: { spawn: true },
+        files: ['test/fixtures/tasks/*.js'],
+        tasks: ['series0']
+      },
+      custom: {
+        files: ['test/fixtures/**/*.js'],
+        // Specify a custom task runner of your choosing
+        tasks: function (target, options, done) {
+          // Get changed files
+          var changedFiles = grunt.config(target + '.changed');
+          // Do something custom
+          grunt.log.writeln('My custom task runner for ' + target);
+          // Call when done
+          done();
+        }
+      },
+    }
   });
   grunt.registerTask('series0', function () {
     var done = this.async();
@@ -51,6 +75,8 @@ module.exports = function (grunt) {
   grunt.registerMultiTask('multi', function () {
     console.log(this);
   });
+
+  grunt.loadTasks('watch');
 
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-concat');

--- a/watch/lib/runner.js
+++ b/watch/lib/runner.js
@@ -1,0 +1,103 @@
+const inherits = require('util').inherits;
+const EE = require('events').EventEmitter;
+const spawn = require('child_process').spawn;
+const Orchestrator = require('orchestrator');
+const parseCommands = require('../../runner/lib/parse_commands');
+const indexCommands = require('../../runner/lib/index_commands');
+const buildTaskList = require('../../runner/lib/build_task_list');
+
+function Runner (grunt) {
+  if (!(this instanceof Runner)) { return new Runner(grunt); }
+  EE.call(this);
+  this.grunt = grunt;
+  this.running = false;
+  this.runner = null;
+  this.spawner = null;
+}
+module.exports = Runner;
+inherits(Runner, EE);
+
+Runner.prototype.run = function (request, options, cb) {
+  var self = this;
+
+  // Interrupt current tasks
+  if (this.running && options.interrupt === true) {
+    return this.interrupt(function() {
+      self.run(request, options, cb);
+    });
+  }
+
+  this.running = true;
+  var start = Date.now();
+  this[options.spawn ? 'spawn' : 'nospawn'](request, options, function() {
+    self.running = false;
+    cb(Date.now() - start);
+  });
+};
+
+// TODO: This could probably just use grunt.run the orchestrator instance is exposed
+Runner.prototype.nospawn = function (request, options, cb) {
+  var self = this;
+  this.grunt.emit('run.request', request);
+
+  // remove invalid requests / resolve aliases / expand multi tasks
+  var commands = parseCommands(this.grunt.config, this.grunt.tasks, request);
+  this.grunt.emit('run.parseCommands', commands);
+
+  // group commands by their root task
+  var indexedCommands = indexCommands(commands);
+  this.grunt.emit('run.indexCommands', indexedCommands);
+
+  // build a listing of tasks to put into orchestrator
+  var taskList = buildTaskList(this.grunt.config, this.grunt.tasks, indexedCommands);
+  this.grunt.emit('run.buildTaskList', taskList);
+
+  // build an orchestration
+  this.runner = new Orchestrator();
+  taskList.forEach(function (task) {
+    self.runner.add(task.name, task.method);
+  });
+
+  // emit some stuff (this.grunt will be cleaned up in the next v of orchestrator)
+  this.runner.on('task_start', function (e) {
+    // this.grunt will not be reliable when running tasks concurrently!
+    self.grunt.task.current = self.runner.tasks[e.task].fn.context;
+    self.grunt.emit('task_start', e);
+  });
+  this.runner.on('task_stop', function (e) {
+    self.grunt.task.current = null;
+    self.grunt.emit('task_stop', e);
+  });
+
+  // run it!
+  this.runner.start(commands, cb);
+};
+
+Runner.prototype.spawn = function (request, options, cb) {
+  if (!Array.isArray(request)) { request = [request]; }
+  // TODO: Use wait-grunt instead here
+  // TODO: Use mtime to write a manifest so changed files are available to spawn'd tasks
+  this.spawner = this.grunt.util.spawn({
+    grunt: true,
+    opts: {
+      stdio: 'inherit',
+      cwd: options.cwd,
+    },
+    args: request.concat(options.cliArgs || []),
+  }, cb);
+};
+
+// Interrupt the current running tasks
+Runner.prototype.interrupt = function (cb) {
+  this.running = false;
+  this.runner = null;
+  this.spawner = null;
+  this.emit('interrupt');
+  if (this.runner) {
+    this.runner.stop();
+    cb();
+  } else if (this.spawner) {
+    this.spawner.on('close', cb);
+    this.spawner.kill();
+  }
+};

--- a/watch/watch.js
+++ b/watch/watch.js
@@ -1,0 +1,75 @@
+module.exports = function (grunt) {
+  const gaze = require('gaze');
+  const _ = require('lodash');
+  const runner = require('./lib/runner.js')(grunt);
+
+  grunt.registerMultiTask('watch', function() {
+    var name = this.name || 'watch';
+    var files = this.data.files;
+    var tasks = this.data.tasks;
+    var target = this.target;
+    var options = this.options({
+      spawn: false,
+      cliArgs: _.without.apply(null, [[].slice.call(process.argv, 2)].concat(grunt.env.argv._)),
+      atBegin: false,
+      interrupt: false,
+      event: ['all'],
+      cwd: grunt.env.cwd,
+      livereload: false, // TODO: not yet implemented
+    });
+
+    // When files are changed, call the runner
+    var changedFiles = Object.create(null);
+    grunt.config([name, target, 'changed'].join('.'), []);
+    var changed = _.debounce(function(tasks, options, cb) {
+      grunt.config([name, target, 'changed'].join('.'), Object.keys(changedFiles));
+      if (typeof tasks === 'function') {
+        // If tasks is a custom function, run that instead
+        var start = Date.now();
+        tasks([name, target].join('.'), options, function() {
+          cb(Date.now() - start);
+        });
+      } else {
+        // Otherwise use the built in runner
+        runner.run(tasks, options, cb);
+      }
+    }, 100);
+
+    // Start up gaze on the file patterns
+    function start() {
+      gaze(files, function () {
+        grunt.log.writeln('Watching ' + target + '...');
+        this.on('all', function(event, filepath) {
+
+          // Skip events not specified
+          if (!_.contains(options.event, 'all') && !_.contains(options.event, event)) {
+            return;
+          }
+
+          // Track changed files and notify changed has occurred
+          changedFiles[filepath] = event;
+          changed(tasks, options, function(time) {
+            grunt.log.writeln('Completed "' + target + '" tasks in ' + (time || 0 / 1000) + ' s. Waiting...');
+            changedFiles = Object.create(null);
+          });
+        });
+      });
+    }
+
+    // If we want to run tasks at the beginning
+    if (options.atBegin) {
+      grunt.log.writeln('Running "' + target + '" at beginning...');
+      changed(tasks, options, start);
+    } else {
+      start();
+    }
+  });
+};
+
+// TODO: doesnt yet use mtime for traversing file dependencies for changed files
+// TODO: fix formatting on completed time displayed
+// TODO: no options.dateFormat implementation
+// TODO: no advanced options.cwd implementation
+// TODO: no livereload (does it still belong in the watch? - shama)
+// TODO: no watch event (I want to nix it - shama)
+


### PR DESCRIPTION
Here is a start of the watch task implementation. I am testing using [gaze@0.6.0](https://github.com/shama/gaze/tree/v0.6) which will be released soon and has many performance updates.

This watch task has parity with the grunt-contrib-watch except for:
- Defaults to `spawn: false` instead of spawning (let everyone besides me rejoice)
- No livereload (Im thinking about whether this still belongs in watch, probably still yes)
- No `dateFormat` or proper date/time formatting
- Just accepts `cwd` and not the advanced `cwd: { spawn: filepath, tasks: filepath }` options
- No `watch` event emitted (I want to nix this as I think it is horrible)
- Does not reload Gruntfile when changed.

The enhancements it has over the current watch task are:
- `changed` files are appended to the watch target's config. This lets users easily configure other tasks to operate on changed files `'<%= watch.target.changed %>`. And if mtime is integrated into grunt, it could handle file dependency trees or changed files based on SHAs in a generic way as well.
- Allows `tasks` to be set to a custom function. Which overrides the internal task runner if the user wants to add their own custom task runner (this is far superior to the watch event).

---

Currently as a separate task but could easily become a part of Grunt's core instead.
